### PR TITLE
fix: kill orphaned osascript on timeout to prevent Mail freeze

### DIFF
--- a/plugin/apple_mail_mcp/core.py
+++ b/plugin/apple_mail_mcp/core.py
@@ -52,23 +52,29 @@ def _sanitize_for_json(text: str) -> str:
 
 def run_applescript(script: str, timeout: int = 120) -> str:
     """Execute AppleScript via stdin pipe for reliable multi-line handling."""
+    proc = subprocess.Popen(
+        ["osascript", "-"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     try:
-        result = subprocess.run(
-            ["osascript", "-"],
-            input=script.encode("utf-8"),
-            capture_output=True,
-            timeout=timeout,
-        )
-        if result.returncode != 0:
-            stderr = result.stderr.decode("utf-8", errors="replace").strip()
-            if stderr:
-                raise Exception(f"AppleScript error: {stderr}")
-        output = result.stdout.decode("utf-8", errors="replace").strip()
-        return _sanitize_for_json(output)
+        stdout, stderr = proc.communicate(input=script.encode("utf-8"), timeout=timeout)
     except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate()  # drain pipes so the process exits cleanly
         raise Exception("AppleScript execution timed out")
     except Exception as e:
+        proc.kill()
+        proc.communicate()
         raise Exception(f"AppleScript execution failed: {str(e)}")
+
+    if proc.returncode != 0:
+        stderr_text = stderr.decode("utf-8", errors="replace").strip()
+        if stderr_text:
+            raise Exception(f"AppleScript error: {stderr_text}")
+    output = stdout.decode("utf-8", errors="replace").strip()
+    return _sanitize_for_json(output)
 
 
 def normalize_search_terms(

--- a/plugin/apple_mail_mcp/tools/manage.py
+++ b/plugin/apple_mail_mcp/tools/manage.py
@@ -119,7 +119,7 @@ def move_email(
 
     script = f'''
     tell application "Mail"
-        with timeout of 300 seconds
+        with timeout of 270 seconds
             set outputText to "{mode_label}: {safe_from} -> {safe_to}" & return & return
             set moveCount to 0
 
@@ -353,7 +353,7 @@ def update_email_status(
 
         script = f'''
         tell application "Mail"
-            with timeout of 300 seconds
+            with timeout of 270 seconds
                 set outputText to "UPDATING EMAIL STATUS BY IDS: {action_label}" & return & return
                 set updateCount to 0
 
@@ -444,7 +444,7 @@ def update_email_status(
 
     script = f'''
     tell application "Mail"
-        with timeout of 300 seconds
+        with timeout of 270 seconds
             set outputText to "UPDATING EMAIL STATUS: {action_label}" & return & return
             set updateCount to 0
 
@@ -601,7 +601,7 @@ def manage_trash(
 
         script = f'''
         tell application "Mail"
-            with timeout of 300 seconds
+            with timeout of 270 seconds
                 set outputText to "PERMANENTLY DELETING EMAILS" & return & return
                 set deleteCount to 0
 
@@ -692,7 +692,7 @@ def manage_trash(
 
         script = f'''
         tell application "Mail"
-            with timeout of 300 seconds
+            with timeout of 270 seconds
                 set outputText to "{mode_label}" & return & return
                 set deleteCount to 0
 

--- a/plugin/apple_mail_mcp/tools/search.py
+++ b/plugin/apple_mail_mcp/tools/search.py
@@ -385,7 +385,7 @@ def _search_mail_records(
     end iso_datetime
 
     tell application "Mail"
-        with timeout of 180 seconds
+        with timeout of 150 seconds
             try
                 set recordLines to {{}}
                 set offsetRemaining to {offset}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,29 @@
+"""Tests for core AppleScript execution helpers."""
+
+import subprocess
+import unittest
+from unittest.mock import MagicMock, patch
+
+from apple_mail_mcp import core
+
+
+class RunAppleScriptTests(unittest.TestCase):
+    def test_kills_process_on_timeout(self):
+        # Apple Mail's Apple-Events bridge is single-threaded. If osascript is
+        # left running after a Python-level timeout, it holds the event queue
+        # and every subsequent MCP call hangs. Pin the kill+drain behavior.
+        proc = MagicMock()
+        proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="osascript", timeout=1),
+            (b"", b""),
+        ]
+        with patch("apple_mail_mcp.core.subprocess.Popen", return_value=proc):
+            with self.assertRaisesRegex(Exception, "timed out"):
+                core.run_applescript("return 1", timeout=1)
+
+        proc.kill.assert_called_once()
+        self.assertEqual(proc.communicate.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1

## Summary

- `run_applescript` in `core.py`: swap `subprocess.run(timeout=...)` for `subprocess.Popen` + `proc.communicate(timeout=...)`, and on `TimeoutExpired` (or any other exception) call `proc.kill()` + drain pipes before re-raising. This guarantees `osascript` is dead before control returns to the MCP, freeing Mail's single-threaded Apple-Events queue.
- Stagger AppleScript-side timeouts below the Python kill timeout so AppleScript exits cleanly with a proper error first:
  - `search.py` `_search_mail_records`: `with timeout of 180 seconds` → `150 seconds` (Python stays 180s).
  - `manage.py` move / update / trash (5 sites): `with timeout of 300 seconds` → `270 seconds` (Python stays 300s).

## Why

`subprocess.run(..., timeout=N)` raises `TimeoutExpired` but Python's own docs say the caller must call `.kill()` themselves — the child process is not terminated automatically. Apple Mail's OSA bridge is single-threaded, so an orphaned `osascript` holds the event queue indefinitely. Every subsequent MCP call queues behind the dead-but-not-killed loop and appears completely frozen.

Reproducer: `search_emails` with `body_text` against a large mailbox (~7.7K messages in Sent Items) hits the Python timeout; every call after that hangs until Mail is quit.

## Test plan

- [x] `pytest tests/` — all 25 tests pass (new: `tests/test_core.py::RunAppleScriptTests::test_kills_process_on_timeout`).
- [x] Manual: against a mailbox large enough to trigger the 180s Python timeout on `body_text` search, verify subsequent tool calls (`list_inbox_emails`, a small `search_emails`) no longer hang.

## Non-scope

Does not change any tool signatures, return shapes, or behaviors outside the timeout path. Date filtering, `get_email`, and the attachment resource are separate outcomes to be landed in their own PRs.