### PR TITLE
feat(inbox): pre-scan date filtering; fix silently-ignored account filter in text output

### DIFF
--- a/plugin/apple_mail_mcp/core.py
+++ b/plugin/apple_mail_mcp/core.py
@@ -1,7 +1,41 @@
 """Core helpers: AppleScript execution, escaping, parsing, and preference injection."""
 
 import subprocess
+from datetime import datetime
 from typing import Optional, List, Dict, Any, Tuple
+
+
+MONTH_NAMES = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+]
+
+
+def build_applescript_date(
+    var_name: str, date_value: Optional[str], end_of_day: bool = False
+) -> str:
+    """Build an AppleScript snippet that sets *var_name* to a date from an ISO string (YYYY-MM-DD).
+
+    Pass end_of_day=True to set the time to 23:59:59 (useful for inclusive upper bounds).
+    Returns an empty string when date_value is None so callers can always concatenate safely.
+    """
+    if not date_value:
+        return ""
+    try:
+        parsed = datetime.strptime(date_value, "%Y-%m-%d")
+    except ValueError:
+        raise ValueError(f"Invalid date '{date_value}'. Use YYYY-MM-DD")
+
+    month_name = MONTH_NAMES[parsed.month - 1]
+    seconds = 86399 if end_of_day else 0
+    return f"""
+                set {var_name} to current date
+                set year of {var_name} to {parsed.year}
+                set month of {var_name} to {month_name}
+                set day of {var_name} to {parsed.day}
+                set time of {var_name} to {seconds}
+    """
+
 
 from apple_mail_mcp.server import USER_PREFERENCES
 

--- a/plugin/apple_mail_mcp/tools/inbox.py
+++ b/plugin/apple_mail_mcp/tools/inbox.py
@@ -5,6 +5,7 @@ from typing import Optional, List, Dict, Any
 
 from apple_mail_mcp.server import mcp
 from apple_mail_mcp.core import (
+    build_applescript_date,
     inject_preferences,
     escape_applescript,
     run_applescript,
@@ -43,6 +44,8 @@ def list_inbox_emails(
     include_read: bool = True,
     include_content: bool = False,
     output_format: str = "text",
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
 ) -> str:
     """
     List all emails from inbox across all accounts or a specific account.
@@ -56,26 +59,52 @@ def list_inbox_emails(
         include_read: Whether to include read emails (default: True)
         include_content: Whether to include a content preview for each email (slower, default: False)
         output_format: "text" (default, human-readable) or "json" (structured list of email dicts)
+        date_from: Only include emails on or after this date, ISO format YYYY-MM-DD (e.g. "2024-01-15").
+                   Applied as a pre-scan filter to avoid timeouts on large mailboxes.
+        date_to: Only include emails on or before this date, ISO format YYYY-MM-DD (e.g. "2024-01-15").
+                 Applied as a pre-scan filter to avoid timeouts on large mailboxes.
 
     Returns:
         Formatted list of emails with subject, sender, date, and read status
     """
 
     if output_format == "json":
-        return _list_inbox_emails_json(account, max_emails, include_read, include_content)
+        return _list_inbox_emails_json(
+            account, max_emails, include_read, include_content, date_from, date_to
+        )
+
+    date_setup = build_applescript_date("fromDate", date_from)
+    date_setup += build_applescript_date("toDate", date_to, end_of_day=True)
+
+    filter_conditions = []
+    if not include_read:
+        filter_conditions.append("read status is false")
+    if date_from:
+        filter_conditions.append("date received >= fromDate")
+    if date_to:
+        filter_conditions.append("date received <= toDate")
+
+    if filter_conditions:
+        message_fetch = f"set inboxMessages to every message of inboxMailbox whose {' and '.join(filter_conditions)}"
+    else:
+        message_fetch = "set inboxMessages to every message of inboxMailbox"
+
+    account_open = f'if accountName is "{escape_applescript(account)}" then' if account else ""
+    account_close = "end if" if account else ""
 
     script = f"""
     tell application "Mail"
         set outputText to "INBOX EMAILS - ALL ACCOUNTS" & return & return
         set totalCount to 0
         set allAccounts to every account
+        {date_setup}
 
         repeat with anAccount in allAccounts
             set accountName to name of anAccount
-
+            {account_open}
             try
                 {inbox_mailbox_script("inboxMailbox", "anAccount")}
-                set inboxMessages to every message of inboxMailbox
+                {message_fetch}
                 set messageCount to count of inboxMessages
 
                 if messageCount > 0 then
@@ -94,28 +123,21 @@ def list_inbox_emails(
                             set messageDate to date received of aMessage
                             set messageRead to read status of aMessage
 
-                            set shouldInclude to true
-                            if not {str(include_read).lower()} and messageRead then
-                                set shouldInclude to false
+                            if messageRead then
+                                set readIndicator to "✓"
+                            else
+                                set readIndicator to "✉"
                             end if
 
-                            if shouldInclude then
-                                if messageRead then
-                                    set readIndicator to "✓"
-                                else
-                                    set readIndicator to "✉"
-                                end if
+                            set outputText to outputText & readIndicator & " " & messageSubject & return
+                            set outputText to outputText & "   From: " & messageSender & return
+                            set outputText to outputText & "   Date: " & (messageDate as string) & return
 
-                                set outputText to outputText & readIndicator & " " & messageSubject & return
-                                set outputText to outputText & "   From: " & messageSender & return
-                                set outputText to outputText & "   Date: " & (messageDate as string) & return
+                            {content_preview_script(200) if include_content else ""}
 
-                                {content_preview_script(200) if include_content else ""}
+                            set outputText to outputText & return
 
-                                set outputText to outputText & return
-
-                                set totalCount to totalCount + 1
-                            end if
+                            set totalCount to totalCount + 1
                         end try
                     end repeat
                 end if
@@ -123,6 +145,7 @@ def list_inbox_emails(
                 set outputText to outputText & "⚠ Error accessing inbox for account " & accountName & return
                 set outputText to outputText & "   " & errMsg & return & return
             end try
+            {account_close}
         end repeat
 
         set outputText to outputText & "========================================" & return
@@ -142,22 +165,41 @@ def _list_inbox_emails_json(
     max_emails: int,
     include_read: bool,
     include_content: bool = False,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
 ) -> str:
     """Return inbox emails as a JSON string."""
     escaped_account = escape_applescript(account) if account else None
     account_filter = f'if accountName is "{escaped_account}" then' if account else ""
     account_filter_end = "end if" if account else ""
 
+    date_setup = build_applescript_date("fromDate", date_from)
+    date_setup += build_applescript_date("toDate", date_to, end_of_day=True)
+
+    filter_conditions = []
+    if not include_read:
+        filter_conditions.append("read status is false")
+    if date_from:
+        filter_conditions.append("date received >= fromDate")
+    if date_to:
+        filter_conditions.append("date received <= toDate")
+
+    if filter_conditions:
+        message_fetch = f"set inboxMessages to every message of inboxMailbox whose {' and '.join(filter_conditions)}"
+    else:
+        message_fetch = "set inboxMessages to every message of inboxMailbox"
+
     script = f"""
     tell application "Mail"
         set resultLines to {{}}
         set allAccounts to every account
+        {date_setup}
         repeat with anAccount in allAccounts
             set accountName to name of anAccount
             {account_filter}
             try
                 {inbox_mailbox_script("inboxMailbox", "anAccount")}
-                set inboxMessages to every message of inboxMailbox
+                {message_fetch}
                 set currentIndex to 0
                 repeat with aMessage in inboxMessages
                     set currentIndex to currentIndex + 1
@@ -167,13 +209,7 @@ def _list_inbox_emails_json(
                         set messageSender to sender of aMessage
                         set messageDate to date received of aMessage
                         set messageRead to read status of aMessage
-                        set shouldInclude to true
-                        if not {str(include_read).lower()} and messageRead then
-                            set shouldInclude to false
-                        end if
-                        if shouldInclude then
-                            set end of resultLines to messageSubject & "|||" & messageSender & "|||" & (messageDate as string) & "|||" & messageRead & "|||" & accountName
-                        end if
+                        set end of resultLines to messageSubject & "|||" & messageSender & "|||" & (messageDate as string) & "|||" & messageRead & "|||" & accountName
                     end try
                 end repeat
             end try

--- a/plugin/apple_mail_mcp/tools/search.py
+++ b/plugin/apple_mail_mcp/tools/search.py
@@ -2,12 +2,12 @@
 
 import json
 import re
-from datetime import datetime
 from typing import Optional, List, Dict, Any
 from urllib.parse import quote
 
 from apple_mail_mcp.server import mcp
 from apple_mail_mcp.core import (
+    build_applescript_date,
     contains_any_condition,
     inject_preferences,
     escape_applescript,
@@ -15,45 +15,6 @@ from apple_mail_mcp.core import (
     run_applescript,
     LOWERCASE_HANDLER,
 )
-
-
-MONTH_NAMES = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-]
-
-
-def _build_applescript_date(
-    var_name: str, date_value: Optional[str], end_of_day: bool = False
-) -> str:
-    """Build AppleScript to create a date from an ISO day string."""
-    if not date_value:
-        return ""
-
-    try:
-        parsed_date = datetime.strptime(date_value, "%Y-%m-%d")
-    except ValueError:
-        raise ValueError(f"Invalid date '{date_value}'. Use YYYY-MM-DD")
-
-    month_name = MONTH_NAMES[parsed_date.month - 1]
-    seconds = 86399 if end_of_day else 0
-    return f"""
-                set {var_name} to current date
-                set year of {var_name} to {parsed_date.year}
-                set month of {var_name} to {month_name}
-                set day of {var_name} to {parsed_date.day}
-                set time of {var_name} to {seconds}
-    """
 
 
 def _parse_search_records(output: str) -> List[Dict[str, Any]]:
@@ -255,8 +216,8 @@ def _search_mail_records(
         '''
         skip_script = ""
 
-    date_setup = _build_applescript_date("fromDate", date_from)
-    date_setup += _build_applescript_date("toDate", date_to, end_of_day=True)
+    date_setup = build_applescript_date("fromDate", date_from)
+    date_setup += build_applescript_date("toDate", date_to, end_of_day=True)
 
     # Build account iteration
     if account:

--- a/tests/test_inbox_tools.py
+++ b/tests/test_inbox_tools.py
@@ -1,0 +1,50 @@
+"""Tests for list_inbox_emails filtering (date, read-status, account)."""
+
+import unittest
+from unittest.mock import patch
+
+from apple_mail_mcp.tools import inbox as inbox_tools
+
+
+class ListInboxEmailsFilterTests(unittest.TestCase):
+    def _capture_script(self, **kwargs):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.inbox.run_applescript", side_effect=fake_run):
+            inbox_tools.list_inbox_emails(**kwargs)
+        return captured["script"]
+
+    def test_date_from_and_to_build_prescan_whose_clause(self):
+        # Date filtering must run as an AppleScript `whose` pre-filter so Mail
+        # doesn't iterate the whole mailbox first on large accounts.
+        script = self._capture_script(date_from="2026-03-01", date_to="2026-03-07")
+        self.assertIn("set year of fromDate to 2026", script)
+        self.assertIn("set month of fromDate to March", script)
+        self.assertIn("set year of toDate to 2026", script)
+        self.assertIn("date received >= fromDate", script)
+        self.assertIn("date received <= toDate", script)
+        self.assertIn("every message of inboxMailbox whose", script)
+
+    def test_include_read_false_moves_into_whose_clause(self):
+        # Previously evaluated per-message in Python-ish AppleScript; must now
+        # be part of the `whose` pre-filter so Mail can skip fetching reads.
+        script = self._capture_script(include_read=False)
+        self.assertIn("whose read status is false", script)
+
+    def test_text_variant_honors_account_filter(self):
+        # Regression: the text output previously ignored `account` entirely
+        # and iterated every account.
+        script = self._capture_script(account="Work")
+        self.assertIn('if accountName is "Work" then', script)
+
+    def test_invalid_date_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, "YYYY-MM-DD"):
+            inbox_tools.list_inbox_emails(date_from="not-a-date")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3

## Summary

- `list_inbox_emails` gains `date_from` / `date_to` params (ISO `YYYY-MM-DD`) applied as an AppleScript `whose` pre-filter, so Mail skips non-matching messages before iteration. Chunking by day (e.g. `date_from="2024-04-22"` + `date_to="2024-04-22"`) no longer times out on large mailboxes.
- The `include_read=False` filter is moved from a Python-time per-message check into the same `whose` clause — same semantics, much cheaper on large inboxes.
- **Bug fix**: the text output variant previously ignored the `account` argument entirely and iterated every account; it now wraps the per-account body in `if accountName is "<account>" then … end if` to match the JSON variant.
- The private `_build_applescript_date` helper in `search.py` is promoted into `core.py` as `build_applescript_date` so `inbox.py` can share it. Pure relocation; `search.py` call sites renamed transparently.

## Behavior change note

Callers that passed `account=\"X\"` to `list_inbox_emails` with the default `output_format=\"text\"` will now actually see only account X's inbox. Previously that argument was silently dropped. No other behavior is affected at default settings.

## Test plan

- [x] `pytest tests/` — 28 / 28 pass, including 4 new inbox tests in `tests/test_inbox_tools.py`:
  - date_from + date_to produce a `whose` pre-scan clause with both bounds
  - `include_read=False` becomes `whose read status is false`
  - text-variant with `account=\"Work\"` produces `if accountName is \"Work\" then`
  - invalid date strings raise `ValueError(\"... YYYY-MM-DD\")`
- [x] Manual: run `list_inbox_emails(date_from=\"<yesterday>\", date_to=\"<yesterday>\")` against a large mailbox and confirm it returns quickly rather than timing out.

## Non-scope

- Does not expose `message_id` / `internet_message_id` / `mail_link` in the JSON output. Parser stays 5-field. That's a follow-up issue.
- Does not add `get_email` or the attachment resource. Separate follow-up.
- Does not include the orphaned-`osascript` kill fix (separate branch #2 already under review).