### PR TITLE
feat(inbox): expose message_id, internet_message_id, and mail_link in JSON output

### DIFF
--- a/plugin/apple_mail_mcp/tools/inbox.py
+++ b/plugin/apple_mail_mcp/tools/inbox.py
@@ -2,6 +2,7 @@
 
 import json
 from typing import Optional, List, Dict, Any
+from urllib.parse import quote
 
 from apple_mail_mcp.server import mcp
 from apple_mail_mcp.core import (
@@ -15,7 +16,12 @@ from apple_mail_mcp.core import (
 
 
 def _parse_pipe_delimited_emails(raw: str) -> List[Dict[str, Any]]:
-    """Parse '|||'-delimited AppleScript output into a list of email dicts."""
+    """Parse '|||'-delimited AppleScript output into a list of email dicts.
+
+    Accepts 5-field legacy rows and 6/7-field rows that add message_id and
+    internet_message_id. When internet_message_id is present, a mail_link
+    deep-link is derived the same way search_emails does.
+    """
     emails = []
     if not raw:
         return emails
@@ -23,16 +29,27 @@ def _parse_pipe_delimited_emails(raw: str) -> List[Dict[str, Any]]:
         if "|||" not in line:
             continue
         parts = line.split("|||")
-        if len(parts) >= 5:
-            emails.append(
-                {
-                    "subject": parts[0].strip(),
-                    "sender": parts[1].strip(),
-                    "date": parts[2].strip(),
-                    "is_read": parts[3].strip().lower() == "true",
-                    "account": parts[4].strip(),
-                }
-            )
+        if len(parts) < 5:
+            continue
+        record: Dict[str, Any] = {
+            "subject": parts[0].strip(),
+            "sender": parts[1].strip(),
+            "date": parts[2].strip(),
+            "is_read": parts[3].strip().lower() == "true",
+            "account": parts[4].strip(),
+        }
+        if len(parts) >= 6:
+            record["message_id"] = parts[5].strip()
+        if len(parts) >= 7:
+            internet_mid = parts[6].strip()
+            record["internet_message_id"] = internet_mid
+            if internet_mid:
+                # Apple Mail deep link: message:// + percent-encoded angle brackets
+                # + raw @ in the Message-ID. Strip brackets first since AppleScript
+                # returns both forms depending on message source.
+                msg_id = internet_mid.strip("<>")
+                record["mail_link"] = f"message://%3C{quote(msg_id, safe='@')}%3E"
+        emails.append(record)
     return emails
 
 
@@ -209,7 +226,12 @@ def _list_inbox_emails_json(
                         set messageSender to sender of aMessage
                         set messageDate to date received of aMessage
                         set messageRead to read status of aMessage
-                        set end of resultLines to messageSubject & "|||" & messageSender & "|||" & (messageDate as string) & "|||" & messageRead & "|||" & accountName
+                        set messageNumId to id of aMessage as string
+                        set internetMid to ""
+                        try
+                            set internetMid to message id of aMessage
+                        end try
+                        set end of resultLines to messageSubject & "|||" & messageSender & "|||" & (messageDate as string) & "|||" & messageRead & "|||" & accountName & "|||" & messageNumId & "|||" & internetMid
                     end try
                 end repeat
             end try

--- a/tests/test_inbox_tools.py
+++ b/tests/test_inbox_tools.py
@@ -1,5 +1,6 @@
-"""Tests for list_inbox_emails filtering (date, read-status, account)."""
+"""Tests for list_inbox_emails filtering (date, read-status, account) and JSON ID exposure."""
 
+import json
 import unittest
 from unittest.mock import patch
 
@@ -44,6 +45,63 @@ class ListInboxEmailsFilterTests(unittest.TestCase):
     def test_invalid_date_raises_value_error(self):
         with self.assertRaisesRegex(ValueError, "YYYY-MM-DD"):
             inbox_tools.list_inbox_emails(date_from="not-a-date")
+
+
+class ListInboxEmailsJsonIdsTests(unittest.TestCase):
+    def test_parser_extracts_ids_and_mail_link_from_seven_fields(self):
+        line = "|||".join(
+            [
+                "Hello",
+                "alice@example.com",
+                "Monday, March 7, 2026 at 10:00:00 AM",
+                "false",
+                "Work",
+                "12345",
+                "<abc@mail.example.com>",
+            ]
+        )
+        [record] = inbox_tools._parse_pipe_delimited_emails(line)
+        self.assertEqual(record["message_id"], "12345")
+        self.assertEqual(record["internet_message_id"], "<abc@mail.example.com>")
+        self.assertEqual(
+            record["mail_link"],
+            "message://%3Cabc@mail.example.com%3E",
+        )
+
+    def test_parser_legacy_five_field_rows_stay_clean(self):
+        # Forward-compat: if a caller is still using an old-format emitter or
+        # cached output, we should not spuriously add message_id / mail_link.
+        line = "|||".join(
+            [
+                "Legacy",
+                "bob@example.com",
+                "Monday, March 7, 2026 at 10:00:00 AM",
+                "true",
+                "Personal",
+            ]
+        )
+        [record] = inbox_tools._parse_pipe_delimited_emails(line)
+        self.assertNotIn("message_id", record)
+        self.assertNotIn("internet_message_id", record)
+        self.assertNotIn("mail_link", record)
+
+    def test_json_applescript_emits_numeric_id_and_internet_mid(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.inbox.run_applescript", side_effect=fake_run):
+            inbox_tools.list_inbox_emails(output_format="json")
+
+        script = captured["script"]
+        self.assertIn("set messageNumId to id of aMessage as string", script)
+        self.assertIn("set internetMid to message id of aMessage", script)
+        # Must be wrapped in its own try block because the header is missing
+        # on some Exchange/Outlook messages.
+        self.assertIn("set internetMid to \"\"", script)
+        self.assertIn('& "|||" & messageNumId & "|||" & internetMid', script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #5

## Summary

- `list_inbox_emails(output_format=\"json\")` now returns `message_id`, `internet_message_id`, and `mail_link` per entry, matching what `search_emails` already exposes.
- `_list_inbox_emails_json` AppleScript adds two pipe-delimited fields: `id of aMessage as string` and `message id of aMessage` (the latter wrapped in `try` because the RFC 2822 header is absent on some Exchange/Outlook messages).
- `_parse_pipe_delimited_emails` is extended to parse 6- and 7-field rows; 5-field legacy rows still parse with no extra keys.
- `mail_link` uses the same `message://%3C…%3E` format as `search_emails`, stripping any existing angle brackets before percent-encoding.

## Why

Previously, callers who listed the inbox as JSON had no way to look up, mutate, or open a specific message without re-running a full search. This unblocks the upcoming `get_email` tool (separate PR) and enables direct-action workflows like feeding IDs into `move_email` / `update_email_status` or opening the Mail deep link.

## Behavior change note

Existing 5-field output is still parsed correctly. JSON records previously had 5 keys; they now carry 2–3 additional keys when the underlying row includes the new fields. No fields are removed; consumers that look up known keys are unaffected.

## Test plan

- [x] `pytest tests/` — 32 / 32 pass, including 3 new tests in `tests/test_inbox_tools.py`:
  - 7-field row → dict has `message_id`, `internet_message_id`, `mail_link` with the expected `message://%3C…%3E` value.
  - 5-field legacy row → stays clean, no spurious new keys.
  - JSON AppleScript contains `id of aMessage as string`, `message id of aMessage` inside a `try`, and the `|||` emit appends the two new fields at positions 6 and 7.
- [ ] Manual: `list_inbox_emails(output_format=\"json\", max_emails=3)` against real Mail returns 7-key records with working `mail_link`s.

## Non-scope

Does not add the `get_email` tool or the attachment MCP resource — that is the next (and final) outcome from the session changes.