### PR TITLE
fix(search): has_attachments filter returned 0 results either way

### DIFF
--- a/plugin/apple_mail_mcp/tools/search.py
+++ b/plugin/apple_mail_mcp/tools/search.py
@@ -162,18 +162,16 @@ def _search_mail_records(
     # When body_text is provided, we must iterate per-message (can't use whose clause)
     use_body_search = body_text is not None
 
-    # Build whose-clause filter conditions (only used when NOT doing body search)
+    # Build whose-clause filter conditions (only used when NOT doing body search).
+    # has_attachments is deliberately NOT included here: Mail's whose-filter engine
+    # cannot evaluate `count of <collection>` and silently yields an empty set.
+    # It is applied as a post-filter pass below.
     filter_conditions = []
     if not use_body_search:
         if subject_terms:
             filter_conditions.append(contains_any_condition("subject", subject_terms))
         if sender:
             filter_conditions.append(f'sender contains "{escaped_sender}"')
-        if has_attachments is not None:
-            if has_attachments:
-                filter_conditions.append("(count of mail attachments) > 0")
-            else:
-                filter_conditions.append("(count of mail attachments) = 0")
         if read_status == "read":
             filter_conditions.append("read status is true")
         elif read_status == "unread":
@@ -291,11 +289,33 @@ def _search_mail_records(
     else:
         body_search_loop = ""
 
+    # has_attachments post-filter: can't live in the whose-clause (Mail's filter
+    # engine won't evaluate `count of mail attachments` there). Run one pass over
+    # matchingMessages per mailbox to filter; body_search handles it inline.
+    if has_attachments is not None and not use_body_search:
+        attachment_op = ">" if has_attachments else "="
+        attachments_post_filter = f"""
+                            set filteredMessages to {{}}
+                            repeat with m in matchingMessages
+                                try
+                                    if (count of mail attachments of m) {attachment_op} 0 then
+                                        set end of filteredMessages to m
+                                    end if
+                                end try
+                            end repeat
+                            set matchingMessages to filteredMessages
+        """
+    else:
+        attachments_post_filter = ""
+
     # Choose the message collection strategy
     if use_body_search:
         message_collection = body_search_loop
     else:
-        message_collection = f"                            {matching_messages_script}"
+        message_collection = (
+            f"                            {matching_messages_script}"
+            f"{attachments_post_filter}"
+        )
 
     lowercase_handler = LOWERCASE_HANDLER if use_body_search else ""
 

--- a/tests/test_mail_search_tools.py
+++ b/tests/test_mail_search_tools.py
@@ -259,6 +259,65 @@ class SearchToolTests(unittest.TestCase):
         self.assertIn("on lowercase(str)", captured["script"])
         self.assertIn('lowerContent contains "invoice"', captured["script"])
 
+    def test_has_attachments_true_builds_post_filter_not_whose_clause(self):
+        # Mail's whose-filter engine can't evaluate `count of mail attachments`
+        # — attempting that produces 0 results. The fix applies has_attachments
+        # as a post-filter pass over the matched messages.
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            search_tools.search_emails(
+                account="Work",
+                has_attachments=True,
+                output_format="json",
+                limit=5,
+            )
+
+        script = captured["script"]
+        self.assertNotIn("(count of mail attachments) > 0", script)
+        self.assertNotIn("(count of mail attachments) = 0", script)
+        self.assertIn("(count of mail attachments of m) > 0", script)
+        self.assertIn("set matchingMessages to filteredMessages", script)
+
+    def test_has_attachments_false_uses_equality_operator_in_post_filter(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            search_tools.search_emails(
+                account="Work",
+                has_attachments=False,
+                output_format="json",
+                limit=5,
+            )
+
+        script = captured["script"]
+        self.assertIn("(count of mail attachments of m) = 0", script)
+        self.assertIn("set matchingMessages to filteredMessages", script)
+
+    def test_has_attachments_none_emits_no_post_filter(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            search_tools.search_emails(
+                account="Work",
+                output_format="json",
+                limit=5,
+            )
+
+        self.assertNotIn("filteredMessages", captured["script"])
+
 
 class ManageToolTests(unittest.TestCase):
     def test_update_email_status_with_message_ids_uses_exact_id_condition(self):


### PR DESCRIPTION
Closes #9

## Summary

- Drop `has_attachments` from the AppleScript `whose`-clause in `_search_mail_records`. Mail's whose-filter engine cannot evaluate `count of mail attachments` — it silently yields an empty set (or raises, which the enclosing `try` swallows). Since both `True` and `False` would emit an unevaluable whose, both returned 0 results; the operator never got a chance to discriminate.
- Apply `has_attachments` as a **post-filter pass** over `matchingMessages` after the whose-collection. Keeps the whose-clause fast pre-filter for `subject`, `sender`, `date`, `read_status`. Only iterates when this specific filter is requested; body-text path is untouched (it already handles `has_attachments` correctly inline).

```applescript
set filteredMessages to {}
repeat with m in matchingMessages
    try
        if (count of mail attachments of m) > 0 then   -- or = 0
            set end of filteredMessages to m
        end if
    end try
end repeat
set matchingMessages to filteredMessages
```

Pagination is unaffected — `matchingCount = count of matchingMessages` runs after the rebind.

## Test plan

- [x] `pytest tests/` — 47 / 47 pass, including 3 new tests in `tests/test_mail_search_tools.py`:
  - `has_attachments=True` emits the post-filter with `> 0` and the `filteredMessages` rebind, and does **not** emit the broken `(count of mail attachments) > 0` whose fragment.
  - `has_attachments=False` emits the post-filter with `= 0`.
  - `has_attachments=None` emits no post-filter block at all.
- [x] Manual: `search_emails(has_attachments=True)` against a mailbox with attachment-bearing messages returns results; `has_attachments=False` returns the complement.

## Performance note

When `has_attachments` is used with **no** other narrowing filter, the post-filter iterates the full mailbox — same cost as the body-text path. Users wanting speed on large mailboxes should combine with `subject_keyword`, `sender`, or date bounds, which the whose-clause still pre-filters fast.

## Non-scope

- Does not touch the body-text path (`use_body_search`) — it already evaluates `count of mail attachments of aMessage` correctly in its per-message loop.
- Does not change the signature or return shape of `search_emails`.